### PR TITLE
Clean comments in colony setup

### DIFF
--- a/WorldSim/Game1.cs
+++ b/WorldSim/Game1.cs
@@ -9,12 +9,12 @@ namespace WorldSim
     {
         GraphicsDeviceManager _g;
         SpriteBatch _sb;
-        const float Tick = 0.25f;          // 4×/s szimuláció
+        const float Tick = 0.25f;          // simulation 4× per second
         float _acc;
         World _world;
         SpriteFont _font;
 
-        // tile négyzetháttér mérete (px)
+        // tile square size (px)
         const int TileSize = 4;
         Texture2D _pixel;
 
@@ -24,7 +24,7 @@ namespace WorldSim
             Content.RootDirectory = "Content";
             IsMouseVisible = true;
 
-            // ablakméret beállítása TileSize alapján
+            // set the window size based on TileSize
             _g.PreferredBackBufferWidth = 128 * TileSize;
             _g.PreferredBackBufferHeight = 128 * TileSize;
             _g.ApplyChanges();
@@ -40,7 +40,7 @@ namespace WorldSim
 
         protected override void LoadContent()
         {
-            // SpriteBatch és 1×1 pixel generálása
+            // create SpriteBatch and a 1×1 pixel
             _sb     = new SpriteBatch(GraphicsDevice);
             _pixel  = new Texture2D(GraphicsDevice, 1, 1);
             _pixel.SetData(new[] { Color.White});
@@ -64,7 +64,7 @@ namespace WorldSim
 
             _sb.Begin();
 
-            // Tile-ok kirajzolása
+            // draw tiles
             for (int y = 0; y < _world.Height; y++)
             {
                 for (int x = 0; x < _world.Width; x++)

--- a/WorldSim/Simulation/Colony.cs
+++ b/WorldSim/Simulation/Colony.cs
@@ -28,7 +28,7 @@ namespace WorldSim.Simulation
         public void Update(float dt)
         {
             _age += dt;
-            // később tech-fa, népesség-korlát stb.
+            // later tech tree, population cap, etc.
         }
     }
 }

--- a/WorldSim/Simulation/Person.cs
+++ b/WorldSim/Simulation/Person.cs
@@ -40,7 +40,7 @@ namespace WorldSim.Simulation
                     break;
 
                 case Job.GatherWood:
-                    // próbál fát kitermelni
+                    // attempts to harvest wood
                     if (w.TryHarvest(Pos, Resource.Wood, 1))
                         _home.Stock[Resource.Wood]++;
                     else

--- a/WorldSim/Simulation/Tile.cs
+++ b/WorldSim/Simulation/Tile.cs
@@ -19,7 +19,7 @@ namespace WorldSim.Simulation
         }
 
         /// <summary>
-        /// Megpróbál kitermelni mennyiség() fát/követ…
+        /// Tries to harvest the specified amount of wood or stone...
         /// </summary>
         public bool Harvest(int qty)
         {

--- a/WorldSim/Simulation/World.cs
+++ b/WorldSim/Simulation/World.cs
@@ -21,7 +21,7 @@ namespace WorldSim.Simulation
             Height = height;
             _map = new Tile[width, height];
 
-            // 1. Erőforrások véletlen szórása
+            // 1. Randomly scatter resources
             for (int y = 0; y < Height; y++)
                 for (int x = 0; x < Width; x++)
                     _map[x, y] = new Tile(
@@ -30,32 +30,32 @@ namespace WorldSim.Simulation
                                                    Resource.None,
                         _rng.Next(20, 100));
 
-            // 2. Egyetlen kolónia a térkép közepén
-            // 2. Több kolónia a pályán (3 db példa)
-            int colonyCount = 3; // új sor
-            for (int ci = 0; ci < colonyCount; ci++) // új sor
-            { // új sor
-                var colPos = ( // új sor
-                    _rng.Next(Width / 4, Width * 3 / 4), // új sor (térkép középmezőjébe spawnol)  
-                    _rng.Next(Height / 4, Height * 3 / 4) // új sor
-                ); // új sor
-                var col = new Colony(ci, colPos); // új sor
-                _colonies.Add(col); // új sor
-                                    // 3. Emberek legenerálása ehhez a kolóniához // új sor
-                int pop = initialPop / colonyCount; // új sor
-                for (int i = 0; i < pop; i++) // új sor
-                    _people.Add(Person.Spawn(col, RandomFreePos())); // új sor
+            // 2. Multiple colonies on the map (3 as example)
+            int colonyCount = 3;
+            for (int ci = 0; ci < colonyCount; ci++)
+            {
+                var colPos = (
+                    _rng.Next(Width / 4, Width * 3 / 4), // spawn near the center of the map
+                    _rng.Next(Height / 4, Height * 3 / 4)
+                );
+                var col = new Colony(ci, colPos);
+                _colonies.Add(col);
+
+                // 3. Generate residents for this colony
+                int pop = initialPop / colonyCount;
+                for (int i = 0; i < pop; i++)
+                    _people.Add(Person.Spawn(col, RandomFreePos()));
             }
         }
 
-        // Tick-alapú frissítés
+        // Tick-based update
         public void Update(float dt)
         {
             foreach (var p in _people) p.Update(this, dt);
             foreach (var c in _colonies) c.Update(dt);
         }
 
-        // Ki lehet próbálni így:
+        // Can be tested like this:
         public bool TryHarvest((int x, int y) pos, Resource need, int qty)
         {
             ref Tile tile = ref _map[pos.x, pos.y];
@@ -65,7 +65,7 @@ namespace WorldSim.Simulation
         (int, int) RandomFreePos()
             => (_rng.Next(Width), _rng.Next(Height));
 
-        /// <summary>Visszaadja az (x,y) tile-t a _map-ből.</summary>
+        /// <summary>Returns the tile at (x,y) from _map.</summary>
         public Tile GetTile(int x, int y)
             => _map[x, y];
     }


### PR DESCRIPTION
## Summary
- remove placeholder `// új sor` notes from the colony creation block
- keep concise comments explaining multi-colony setup and citizen spawning
- translate all code comments from Hungarian to English

## Testing
- `dotnet build WorldSim.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095c39328832a8214c2e6f38c6b68