### PR TITLE
Fix resource-specific harvesting

### DIFF
--- a/WorldSim/Simulation/Tile.cs
+++ b/WorldSim/Simulation/Tile.cs
@@ -19,11 +19,17 @@ namespace WorldSim.Simulation
         }
 
         /// <summary>
-        /// Tries to harvest the specified amount of wood or stone...
+        /// Tries to harvest the specified quantity of a given resource.
         /// </summary>
-        public bool Harvest(int qty)
+        /// <param name="res">The type of resource requested.</param>
+        /// <param name="qty">How much to harvest.</param>
+        /// <returns>
+        /// True if this tile contains the requested resource and has
+        /// at least <paramref name="qty"/> amount available; otherwise false.
+        /// </returns>
+        public bool Harvest(Resource res, int qty)
         {
-            if (Type != Resource.None && Amount >= qty)
+            if (Type == res && Amount >= qty)
             {
                 Amount -= qty;
                 return true;

--- a/WorldSim/Simulation/World.cs
+++ b/WorldSim/Simulation/World.cs
@@ -59,7 +59,7 @@ namespace WorldSim.Simulation
         public bool TryHarvest((int x, int y) pos, Resource need, int qty)
         {
             ref Tile tile = ref _map[pos.x, pos.y];
-            return tile.Harvest(qty);
+            return tile.Harvest(need, qty);
         }
 
         (int, int) RandomFreePos()


### PR DESCRIPTION
## Summary
- ensure `World.TryHarvest` checks the requested resource type
- make `Tile.Harvest` resource-aware

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a9e5fb0c832aa6451f546543319a