### PR TITLE
Add age, reproduction, and housing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ A MonoGame-alapú kolónia szimuláció, inspirációként a *WorldBox - God Sim
 ## Fő jellemzők
 
 - 🧍 Egyének attribútumokkal (erő, intelligencia)
+- ⌛ Életkor növekedés és idővel halálozás
+- 👶 Egyszerű szaporodási logika házkapacitás alapján
 - 🪓 Erőforrás-gyűjtés (fa, kő stb.)
-- 🏠 Házépítés kolónián belül
+- 🏠 Házépítés kolónián belül, kapacitáslimit
 - 🌍 Véletlen térkép erőforráseloszlással
 - ⏱️ Tick-alapú szimuláció (4x/sec)
 

--- a/WorldSim/Simulation/Person.cs
+++ b/WorldSim/Simulation/Person.cs
@@ -14,8 +14,9 @@ public class Person
     public (int x, int y) Pos;
     public Job Current = Job.Idle;
     public float Health = 100;
+    public float Age = 0;
     public int Strength, Intelligence;
-    public Colony Home => _home;                 
+    public Colony Home => _home;
     public Color Color => _home.Color;
 
     Colony _home;
@@ -32,8 +33,20 @@ public class Person
     public static Person Spawn(Colony home, (int, int) pos)
         => new Person(home, pos);
 
-    public void Update(World w, float dt)
+    public bool Update(World w, float dt, List<Person> births)
     {
+        Age += dt;
+        if (Age > 80)
+            return false;
+
+        // simple reproduction chance if there is housing capacity
+        int colonyPop = w._people.Count(p => p.Home == _home);
+        int capacity = _home.HouseCount * 4;
+        if (Age >= 18 && Age <= 40 && colonyPop < capacity && _rng.NextDouble() < 0.01)
+        {
+            births.Add(Person.Spawn(_home, Pos));
+        }
+
         switch (Current)
         {
             case Job.Idle:
@@ -52,7 +65,8 @@ public class Person
                 break;
 
             case Job.BuildHouse:
-                if (_home.Stock[Resource.Wood] >= 10)
+                int maxHouses = (int)Math.Ceiling(colonyPop / 4.0);
+                if (_home.HouseCount < maxHouses && _home.Stock[Resource.Wood] >= 10)
                 {
                     _home.Stock[Resource.Wood] -= 10;
                     _home.HouseCount++;
@@ -60,6 +74,7 @@ public class Person
                 Current = Job.Idle;
                 break;
         }
+        return true;
     }
 
     void Wander(World w)

--- a/WorldSim/Simulation/World.cs
+++ b/WorldSim/Simulation/World.cs
@@ -64,7 +64,13 @@ namespace WorldSim.Simulation
         // Tick-based update
         public void Update(float dt)
         {
-            foreach (Person p in _people) p.Update(this, dt);
+            List<Person> births = new();
+            for (int i = _people.Count - 1; i >= 0; i--)
+            {
+                if (!_people[i].Update(this, dt, births))
+                    _people.RemoveAt(i);
+            }
+            _people.AddRange(births);
             foreach (Colony c in _colonies) c.Update(dt);
         }
 


### PR DESCRIPTION
## Summary
- add Age to `Person`
- implement simple birth/death checks and housing capacity
- limit house construction to population needs
- update world update loop to handle births and deaths
- document new gameplay features

## Testing
- `dotnet build WorldSim.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674e4150d4832ab137935efb486ce2