### PR TITLE
Add Iron and Gold resources, world-gen spawns & icons

### DIFF
--- a/WorldSim/Game1.cs
+++ b/WorldSim/Game1.cs
@@ -26,6 +26,8 @@ namespace WorldSim
         Texture2D _pixel;
         Texture2D _treeTex;
         Texture2D _rockTex;
+        Texture2D _ironTex;
+        Texture2D _goldTex;
 
         Texture2D _sylvarsTex;    // person icon (Cyan)
         Texture2D _obsidariTex;   // person icon (Bronze)
@@ -86,6 +88,8 @@ namespace WorldSim
             // PNG icons from Content pipeline
             _treeTex = Content.Load<Texture2D>("tree");
             _rockTex = Content.Load<Texture2D>("rock");
+            _ironTex = Content.Load<Texture2D>("iron");
+            _goldTex = Content.Load<Texture2D>("gold");
 
             // persons
             _sylvarsTex  = Content.Load<Texture2D>("Sylvar");
@@ -295,6 +299,10 @@ namespace WorldSim
                             _sb.Draw(_treeTex, new Rectangle(iconX, iconY, iconSize, iconSize), Color.White);
                         else if (node.Type == Resource.Stone && _rockTex != null)
                             _sb.Draw(_rockTex, new Rectangle(iconX, iconY, iconSize, iconSize), Color.White);
+                        else if (node.Type == Resource.Iron && _ironTex != null)
+                            _sb.Draw(_ironTex, new Rectangle(iconX, iconY, iconSize, iconSize), Color.White);
+                        else if (node.Type == Resource.Gold && _goldTex != null)
+                            _sb.Draw(_goldTex, new Rectangle(iconX, iconY, iconSize, iconSize), Color.White);
                     }
                 }
             }
@@ -362,7 +370,7 @@ namespace WorldSim
             foreach (var colony in _world._colonies)
             {
                 string stats =
-                    $"Colony {colony.Id}: Wood {colony.Stock[Resource.Wood]}, Stone {colony.Stock[Resource.Stone]}, Houses {colony.HouseCount}, People {_world._people.Count(p => p.Home == colony)}";
+                    $"Colony {colony.Id}: Wood {colony.Stock[Resource.Wood]}, Stone {colony.Stock[Resource.Stone]}, Iron {colony.Stock[Resource.Iron]}, Gold {colony.Stock[Resource.Gold]}, Houses {colony.HouseCount}, People {_world._people.Count(p => p.Home == colony)}";
                 _sb.DrawString(_font, stats, new Vector2(10, j), Color.White);
                 j += 20;
             }

--- a/WorldSim/Simulation/Colony.cs
+++ b/WorldSim/Simulation/Colony.cs
@@ -12,6 +12,8 @@ namespace WorldSim.Simulation
         {
             [Resource.Wood] = 0,
             [Resource.Stone] = 0,
+            [Resource.Iron] = 0,
+            [Resource.Gold] = 0,
             [Resource.Food] = 0
         };
         public int HouseCount = 0;

--- a/WorldSim/Simulation/Tile.cs
+++ b/WorldSim/Simulation/Tile.cs
@@ -2,7 +2,7 @@
 
 namespace WorldSim.Simulation
 {
-    public enum Resource { None, Wood, Stone, Food, Water }
+    public enum Resource { None, Wood, Stone, Iron, Gold, Food, Water }
     public enum Ground { Dirt, Water, Grass }
 
     public sealed class ResourceNode

--- a/WorldSim/Simulation/World.cs
+++ b/WorldSim/Simulation/World.cs
@@ -53,13 +53,17 @@ namespace WorldSim.Simulation
                         double r = _rng.NextDouble();
                         if (grounds[x, y] == Ground.Grass)
                         {
-                            if (r < 0.03) node = new ResourceNode(Resource.Wood, _rng.Next(1, 10));          
-                            else if (r < 0.04) node = new ResourceNode(Resource.Stone, _rng.Next(1, 10));   
+                            if (r < 0.03) node = new ResourceNode(Resource.Wood, _rng.Next(1, 10));
+                            else if (r < 0.04) node = new ResourceNode(Resource.Stone, _rng.Next(1, 10));
+                            else if (r < 0.042) node = new ResourceNode(Resource.Iron, _rng.Next(1, 6));
+                            else if (r < 0.043) node = new ResourceNode(Resource.Gold, _rng.Next(1, 4));
                         }
                         else // Dirt
                         {
-                            if (r < 0.02) node = new ResourceNode(Resource.Wood, _rng.Next(1, 10));          
-                            else if (r < 0.028) node = new ResourceNode(Resource.Stone, _rng.Next(1, 10));   
+                            if (r < 0.02) node = new ResourceNode(Resource.Wood, _rng.Next(1, 10));
+                            else if (r < 0.028) node = new ResourceNode(Resource.Stone, _rng.Next(1, 10));
+                            else if (r < 0.031) node = new ResourceNode(Resource.Iron, _rng.Next(1, 6));
+                            else if (r < 0.032) node = new ResourceNode(Resource.Gold, _rng.Next(1, 4));
                         }
                     }
                     _map[x, y] = new Tile(grounds[x, y], node);


### PR DESCRIPTION
### Motivation
- Expand the core resource model with `Iron` and `Gold` to support future tech/building systems and provide immediate visual feedback in the world view.
- Spawn rare, biome-dependent iron/gold nodes so these resources appear naturally on generated maps.
- Render icons and expose colony stock counts for these new resources so players can see and track them in-game.

### Description
- Added `Iron` and `Gold` to the `Resource` enum in `WorldSim/Simulation/Tile.cs`.
- Added `Resource.Iron` and `Resource.Gold` entries to the colony `Stock` dictionary in `WorldSim/Simulation/Colony.cs`.
- Extended world generation in `WorldSim/Simulation/World.cs` to occasionally place `ResourceNode` instances for `Iron` and `Gold` on `Grass` and `Dirt` with small spawn probabilities and limited amounts.
- Loaded `iron` and `gold` textures, added `_ironTex`/`_goldTex` fields and drawing logic to `WorldSim/Game1.cs`, and updated the HUD line to display `Iron` and `Gold` counts.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a5f072368832aaf943f2586caab0f)